### PR TITLE
Prevent page scrolling on touch devices

### DIFF
--- a/script.js
+++ b/script.js
@@ -205,8 +205,14 @@ function addEvents(){
   window.addEventListener('mouseup',   ()=>{ mouseDown = false; });
 
   // タッチ簡易対応
-  window.addEventListener('touchstart', ()=>{ if (playerStats?.type==='laser') mouseDown=true; }, {passive:true});
-  window.addEventListener('touchend',   ()=>{ mouseDown=false; }, {passive:true});
+  window.addEventListener('touchstart', (e)=>{
+    if (playerStats?.type==='laser') mouseDown=true;
+    e.preventDefault();
+  }, {passive:false});
+  window.addEventListener('touchend',   (e)=>{
+    mouseDown=false;
+    e.preventDefault();
+  }, {passive:false});
   window.addEventListener('touchmove', (e)=>{
     if (!running) return;
     const t = e.touches[0]; if (!t) return;
@@ -214,7 +220,8 @@ function addEvents(){
     const dy = (t.clientY / window.innerHeight - 0.5) * -2;
     player.position.x = dx * playerStats.bounds.x;
     player.position.y = dy * playerStats.bounds.y;
-  }, {passive:true});
+    e.preventDefault();
+  }, {passive:false});
 }
 
 function onResize(){

--- a/style.css
+++ b/style.css
@@ -1,8 +1,8 @@
 :root { --bg:#0a0d14; --fg:#e6f0ff; --acc:#61dafb; --mut:#8aa0b3; }
 *{box-sizing:border-box}
-html,body{margin:0;height:100%;background:#000;color:var(--fg);
+html,body{margin:0;height:100%;background:#000;color:var(--fg);overscroll-behavior:none;
   font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial}
-#game{position:fixed;inset:0}
+#game{position:fixed;inset:0;touch-action:none}
 #hud{position:fixed;left:12px;top:12px;z-index:10;font-size:14px;line-height:1.4;
   background:rgba(10,13,20,.5);backdrop-filter:blur(4px);
   border:1px solid rgba(255,255,255,.06);padding:10px 12px;border-radius:10px;min-width:230px}


### PR DESCRIPTION
## Summary
- stop mobile browsers from scrolling the game canvas on touch
- disallow overscroll and default touch actions in CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897e2cd05148330861bda802ad66f64